### PR TITLE
[#43] Server queries use HTTPS instead of HTTP

### DIFF
--- a/src/main/groovy/com/ofg/uptodate/finder/jcenter/JCenterNewVersionFinderFactory.groovy
+++ b/src/main/groovy/com/ofg/uptodate/finder/jcenter/JCenterNewVersionFinderFactory.groovy
@@ -22,7 +22,7 @@ import static com.ofg.uptodate.finder.http.HTTPBuilderProvider.FailureHandlers.l
 @Slf4j
 class JCenterNewVersionFinderFactory implements NewVersionFinderFactory {
 
-    public static final String JCENTER_REPO_URL = "http://jcenter.bintray.com/"
+    public static final String JCENTER_REPO_URL = "https://jcenter.bintray.com/"
 
     @Override
     NewVersionFinder create(UptodatePluginExtension uptodatePluginExtension, List<Dependency> dependencies) {

--- a/src/main/groovy/com/ofg/uptodate/finder/maven/MavenNewVersionFinderFactory.groovy
+++ b/src/main/groovy/com/ofg/uptodate/finder/maven/MavenNewVersionFinderFactory.groovy
@@ -22,7 +22,7 @@ import static com.ofg.uptodate.finder.http.HTTPBuilderProvider.FailureHandlers.l
 @Slf4j
 class MavenNewVersionFinderFactory implements NewVersionFinderFactory {
 
-    public static final String MAVEN_CENTRAL_REPO_URL = "http://search.maven.org/solrsearch/select"
+    public static final String MAVEN_CENTRAL_REPO_URL = "https://search.maven.org/solrsearch/select"
 
     @Override
     NewVersionFinder create(UptodatePluginExtension uptodatePluginExtension, List<Dependency> dependencies) {


### PR DESCRIPTION
It harder to sniff and inject malicious code into HTTPS connection.

Fix #43.