### PR TITLE
Search all repositories

### DIFF
--- a/src/main/groovy/com/ofg/uptodate/UptodatePlugin.groovy
+++ b/src/main/groovy/com/ofg/uptodate/UptodatePlugin.groovy
@@ -2,6 +2,7 @@ package com.ofg.uptodate
 
 import com.ofg.uptodate.dependency.Dependency
 import com.ofg.uptodate.finder.jcenter.JCenterNewVersionFinderFactory
+import com.ofg.uptodate.finder.maven.GenericMavenNewVersionFinderFactory
 import com.ofg.uptodate.finder.maven.MavenNewVersionFinderFactory
 import com.ofg.uptodate.finder.NewVersionFinderInAllRepositories
 import com.ofg.uptodate.reporting.NewVersionProcessor
@@ -10,6 +11,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 
 import javax.inject.Inject
 
@@ -37,9 +39,21 @@ class UptodatePlugin implements Plugin<Project> {
             printMissingJCenterRepoIfApplicable(uptodatePluginExtension, project)
             List<Dependency> dependencies = getDependencies(project)
             if (dependencies) {
+                def repoFinders = project.repositories.findAll{repo ->
+                    repo instanceof MavenArtifactRepository && // Only maven supported
+                    (repo.url.getScheme().equals('http') || repo.url.getScheme().equals('https'))}// No local repos (file://XXXX)
+                    .collect {repo ->
+                        repo.url.toString().equals('https://repo1.maven.org/maven2/') ?
+                            // MavenCentral. This is different from MAVEN_CENTRAL_REPO_URL, which is a *search*-url
+                            new MavenNewVersionFinderFactory().create(uptodatePluginExtension, dependencies)
+                            : repo.url.toString().equals(JCenterNewVersionFinderFactory.JCENTER_REPO_URL) ?
+                                // JCenter
+                                new JCenterNewVersionFinderFactory().create(uptodatePluginExtension, dependencies)
+                                : // Generic maven repo. Alternative: use only GenericMavenNewVersionFinder for all cases
+                                new GenericMavenNewVersionFinderFactory().create(repo.url.toString(), uptodatePluginExtension, dependencies)
+                    }
                 NewVersionFinderInAllRepositories newVersionFinder = new NewVersionFinderInAllRepositories(loggerProxy,
-                        [new MavenNewVersionFinderFactory().create(uptodatePluginExtension, dependencies),
-                         new JCenterNewVersionFinderFactory().create(uptodatePluginExtension, dependencies)])
+                        repoFinders)
                 Set<Dependency> dependenciesWithNewVersions = newVersionFinder.findNewer(dependencies)
                 new NewVersionProcessor(loggerProxy, project.name, uptodatePluginExtension).reportUpdates(dependenciesWithNewVersions)
             } else {

--- a/src/main/groovy/com/ofg/uptodate/finder/maven/GenericMavenNewVersionFinderFactory.groovy
+++ b/src/main/groovy/com/ofg/uptodate/finder/maven/GenericMavenNewVersionFinderFactory.groovy
@@ -1,0 +1,74 @@
+package com.ofg.uptodate.finder.maven
+import java.util.concurrent.Future
+import com.ofg.uptodate.UptodatePluginExtension
+import com.ofg.uptodate.dependency.Dependency
+import com.ofg.uptodate.dependency.Version
+import com.ofg.uptodate.dependency.VersionPatternMatcher
+import com.ofg.uptodate.finder.FinderConfiguration
+import com.ofg.uptodate.finder.NewVersionFinder
+import com.ofg.uptodate.finder.RepositorySettings
+import com.ofg.uptodate.finder.http.HTTPBuilderProvider
+import groovy.util.logging.Slf4j
+import groovy.util.slurpersupport.NodeChild
+import groovyx.net.http.HTTPBuilder
+
+import static com.ofg.uptodate.finder.http.HTTPBuilderProvider.FailureHandlers.logOnlyFailureHandler
+
+@Slf4j
+class GenericMavenNewVersionFinderFactory { // does not: implements NewVersionFinderFactory {
+
+    @Override
+    NewVersionFinder create(String repoUrl, UptodatePluginExtension uptodatePluginExtension, List<Dependency> dependencies) {
+        FinderConfiguration finderConfiguration = new FinderConfiguration(
+                new RepositorySettings(repoUrl: repoUrl, ignoreRepo: false),
+                uptodatePluginExtension,
+                dependencies.size())
+        return new NewVersionFinder(
+                MavenRepoLatestVersionsCollector(finderConfiguration),
+                finderConfiguration)
+    }
+
+    private Closure<Future> MavenRepoLatestVersionsCollector(FinderConfiguration finderConfiguration) {
+        HTTPBuilder httpBuilder = new HTTPBuilderProvider(finderConfiguration.httpConnectionSettings).get()
+        return getLatestFromMavenRepo.curry(httpBuilder, finderConfiguration.excludedVersionPatterns)
+    }
+
+    private Closure<Future> getLatestFromMavenRepo = { HTTPBuilder httpBuilder, List<String> versionToExcludePatterns, Dependency dependency ->
+        httpBuilder.handler.failure = logOnlyFailureHandler(log, dependency.name)
+        handleApplicationUnknownContentTypeAsXml(httpBuilder)
+        String path = httpBuilder.getUri().getPath()
+        if (!path.startsWith('/')) {
+            path = '/'.concat(path)
+        }
+        if (!path.endsWith('/')) {
+            path = path.concat('/')
+        }
+        httpBuilder.get(path: "${path}${dependency.group.split('\\.').join('/')}/${dependency.name}/maven-metadata.xml", contentType : 'application/xml') { resp, xml ->
+            if (!xml) {
+                return []
+            }
+            try {
+                return [dependency, new Dependency(dependency, getLatestDependencyVersion(xml.versioning.release.text(), xml, versionToExcludePatterns))]
+            } catch (Exception e) {
+                log.error("Exception occurred while trying to fetch latest dependencies. The fetched XML is [$xml]".toString(), e)
+                return []
+            }
+        } as Future
+    }
+
+    //application/unknown is returned from jCenter when using CloudFront - #42
+    private void handleApplicationUnknownContentTypeAsXml(HTTPBuilder httpBuilder) {
+        httpBuilder.parser.'application/unknown' = httpBuilder.parser.'application/xml'
+    }
+
+    private Version getLatestDependencyVersion(String releaseVersion, NodeChild xml, List<String> versionToExcludePatterns) {
+        if (new VersionPatternMatcher(releaseVersion).matchesNoneOf(versionToExcludePatterns)) {
+            return new Version(releaseVersion)
+        }
+        return xml.versioning.versions.version.findAll { NodeChild version ->
+            new VersionPatternMatcher(version.text()).matchesNoneOf(versionToExcludePatterns)
+        }.collect {
+            NodeChild version -> new Version(version.text())
+        }.max()
+    }
+}

--- a/src/main/groovy/com/ofg/uptodate/finder/maven/LocalMavenNewVersionFinderFactory.groovy
+++ b/src/main/groovy/com/ofg/uptodate/finder/maven/LocalMavenNewVersionFinderFactory.groovy
@@ -1,0 +1,82 @@
+package com.ofg.uptodate.finder.maven
+
+import com.ofg.uptodate.UptodatePluginExtension
+import com.ofg.uptodate.dependency.Dependency
+import com.ofg.uptodate.dependency.Version
+import com.ofg.uptodate.dependency.VersionPatternMatcher
+import com.ofg.uptodate.finder.FinderConfiguration
+import com.ofg.uptodate.finder.NewVersionFinder
+import com.ofg.uptodate.finder.RepositorySettings
+import groovy.util.logging.Slf4j
+import groovy.util.slurpersupport.NodeChild
+
+import java.util.concurrent.Callable
+import java.util.concurrent.Executors
+import java.util.concurrent.Future
+
+@Slf4j
+class LocalMavenNewVersionFinderFactory { // does not: implements NewVersionFinderFactory {
+
+    @Override
+    NewVersionFinder create(String repoUrl, UptodatePluginExtension uptodatePluginExtension, List<Dependency> dependencies) {
+        FinderConfiguration finderConfiguration = new FinderConfiguration(
+                new RepositorySettings(repoUrl: repoUrl, ignoreRepo: false),
+                uptodatePluginExtension,
+                dependencies.size())
+        return new NewVersionFinder(
+                LocalMavenRepoLatestVersionsCollector(repoUrl, uptodatePluginExtension),
+                finderConfiguration)
+    }
+
+    private Closure<Future> LocalMavenRepoLatestVersionsCollector(String repoUrl, UptodatePluginExtension uptodatePluginExtension) {
+        return getLatestFromLocalMavenRepo.curry(repoUrl, uptodatePluginExtension)
+    }
+
+    private Closure<Future> getLatestFromLocalMavenRepo = { String repoUrl, UptodatePluginExtension uptodatePluginExtension, Dependency dependency ->
+        Closure cl = { ->
+            if (!repoUrl.endsWith('/')) {
+                repoUrl = repoUrl.concat('/')
+            }
+            String newUrl = "${repoUrl}${dependency.group.split('\\.').join('/')}/${dependency.name}/maven-metadata.xml"
+            File file = new File(new URI(newUrl))
+            if (file.exists()) {
+                log.debug("local repo $repoUrl has metadata.xml")
+                // if maven-metadata.xml exists, use that
+                def xml = new XmlSlurper().parse(file)
+                try {
+                    return [dependency, new Dependency(dependency, getLatestDependencyVersion(xml.versioning.release.text(), xml, uptodatePluginExtension.excludedVersionPatterns))]
+                } catch (Exception e) {
+                    log.error("Exception occurred while trying to fetch latest dependencies. The fetched XML is [$xml]".toString(), e)
+                }
+            }
+            // else check for version-subdirectories (f.e. mavenLocal() has no maven-metadata.xml ?)
+            newUrl = "${repoUrl}${dependency.group.split('\\.').join('/')}/${dependency.name}"
+            file = new File(new URI(newUrl))
+            if (file.exists()) {
+                log.debug("fallback to version-directories for $repoUrl")
+                return [dependency, new Dependency(dependency, getLatestDependencyVersion(file, uptodatePluginExtension.excludedVersionPatterns))]
+            }
+            return []
+        }
+        // "Cast" the closure to a Future (since that is what's expected...)
+        return Executors.newSingleThreadExecutor().submit(cl as Callable)
+    }
+
+    private Version getLatestDependencyVersion(String releaseVersion, NodeChild xml, List<String> versionToExcludePatterns) {
+        if (new VersionPatternMatcher(releaseVersion).matchesNoneOf(versionToExcludePatterns)) {
+            return new Version(releaseVersion)
+        }
+        return xml.versioning.versions.version.findAll { NodeChild version ->
+            new VersionPatternMatcher(version.text()).matchesNoneOf(versionToExcludePatterns)
+        }.collect {
+            NodeChild version -> new Version(version.text())
+        }.max()
+    }
+    private Version getLatestDependencyVersion(File parentDir, List<String> versionToExcludePatterns) {
+        return parentDir.listFiles().grep({f -> f.isDirectory()}).findAll {dir ->
+            new VersionPatternMatcher(dir.name).matchesNoneOf(versionToExcludePatterns)
+        }.collect {
+            dir -> new Version(dir.name)
+        }.max()
+    }
+}


### PR DESCRIPTION
This patch enables searching in all repositories configured for the current project.
I needed this because I use fabric.io, which uses it's own (public) repository instead of using maven-central or jcenter.

The second commit in this branch also enables local repositories (i.e. file:/-URLs).
However this is not as important, because Android-Studio is able to notified on these itself (f.e. when there is a newer version of the android-support-library)
