### PR TITLE
[#62] Remove deprecation warning in Gradle 3.2

### DIFF
--- a/src/main/groovy/com/ofg/uptodate/UptodatePlugin.groovy
+++ b/src/main/groovy/com/ofg/uptodate/UptodatePlugin.groovy
@@ -33,7 +33,7 @@ class UptodatePlugin implements Plugin<Project> {
     void apply(Project project) {
         project.extensions.create(TASK_NAME, UptodatePluginExtension)
         UptodatePluginExtension uptodatePluginExtension = project.extensions.uptodate
-        Task createdTask = project.task(TASK_NAME) << { Task task ->
+        Task createdTask = project.task(TASK_NAME).doLast { Task task ->
             printMissingJCenterRepoIfApplicable(uptodatePluginExtension, project)
             List<Dependency> dependencies = getDependencies(project)
             if (uptodatePluginExtension.findBuildDependencies) {


### PR DESCRIPTION
More info: https://docs.gradle.org/3.2/release-notes#the-left-shift-operator-on-the-task-interface